### PR TITLE
日時フォーマットを変更しタイムゾーンを日本時間に変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
-
+gem 'rails-i18n', '~> 6.0'
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.1.5.1)
       actionpack (= 6.1.5.1)
       activesupport (= 6.1.5.1)
@@ -229,6 +232,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4)
+  rails-i18n (~> 6.0)
   sass-rails (>= 6)
   sorcery
   spring

--- a/app/views/boards/_board.html.erb
+++ b/app/views/boards/_board.html.erb
@@ -9,7 +9,7 @@
 <tr>
   <td><%= board.user.name%></td>
   <td><%= board.title%></td>
-  <td><%= board.user.created_at%></td>
+  <td><%= l board.user.created_at%></td>
   <td></td>
 </tr>
 </table>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,10 @@ module LifeApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local  
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,4 @@
+ja:
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M"


### PR DESCRIPTION
rails-i18n をインストールして、日時フォーマットを変更。タイムゾーンは日本時間に変更しja.ymlでどのように表示されるかを指定。