### PR TITLE
logout機能を追加

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,5 @@
 class StaticPagesController < ApplicationController
+  skip_before_action :require_login
   def top
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,7 +6,7 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to boards_path
+      redirect_to boards_path
     else
       flash.now[:alert] = 'Login failed'
       render :new
@@ -15,6 +15,6 @@ class UserSessionsController < ApplicationController
 
   def destroy
     logout
-    redirect_to(:users, notice: 'Logged out!')
+    redirect_to root_path
   end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,6 +5,7 @@
       <div class="mypage">
         <%= link_to "マイページ", board_path(current_user)%>
         <%= link_to "投稿ページ", new_board_path %>
+        <%= link_to "ログアウト", logout_path, method: :delete %>
       </div>
     </li>
   </nav>


### PR DESCRIPTION
logout機能を追加。
ログイン後にログアウトのリンクをヘッダーに設置。
またlogin後logout後のページ先を指定。
ログアウト後にstatic_pagesに移行できるように、ログイン画面をスキップさせるためStatic_pagesコントローラにskip_before_action :require_loginを記載。