### PR TITLE
編集アイコンを削除

### DIFF
--- a/app/views/boards/_crud_menus.html.erb
+++ b/app/views/boards/_crud_menus.html.erb
@@ -3,7 +3,7 @@
   <% if current_user.own?(board) %>
     <li class="list-inline-item">
       <%= link_to edit_board_path(board) ,id: "button-edit-#{board.id}" do %>
-        <%= icon 'fa', 'pen' %>
+        <%# <%= icon 'fa', 'pen' %> %>
       <% end %>
     </li>
   <% end %>


### PR DESCRIPTION
編集アイコンを削除し画面が遷移できるようにする